### PR TITLE
chore: rename project to hybrid-engine-dns; update docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to turboDNS
+# Contributing to hybrid-engine-dns
 
 Thanks for your interest in contributing!
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
-# turboDNS
+# hybrid-engine-dns
 
-Private WIP: a clean, reproducible, and privacy‑focused home lab DNS stack using Docker and BIND9/Unbound.
+Private WIP: a clean, reproducible, and privacy‑focused home lab DNS stack using Docker with BIND9, Unbound, and Pi-hole.
 
 Goals
 - Professional structure and automation from day one
 - Strong defaults for privacy and security
 - Reproducible Docker-based deployment for home networks
+- Support for a private subdomain zone for internal services
 
 Images used
 - ubuntu/bind9:9.18-22.04
 - bind9:9.18-22.04
+- pihole/pihole (version TBD)
 
 Status
 - This repository starts private while building. Once stabilized and documented, it will be made public.
 
 Quick start (placeholder)
-- Coming soon. This will include Docker Compose and configuration examples for BIND9 and Unbound.
+- Coming soon. This will include Docker Compose and configuration examples for BIND9, Unbound, and Pi-hole.
 
 Development
 - CI runs:


### PR DESCRIPTION
This PR renames the repository and updates docs to reflect the new name and stack:\n\n- Repo renamed to hybrid-engine-dns\n- README: title, description updated to include BIND9, Unbound, Pi-hole, and private subdomain\n- CONTRIBUTING: header updated\n\nCI (status check: 'ci') should run on this PR. After it passes, merge to apply the rename-related doc changes to main.