### PR TITLE
feat: import sanitized DNS stack (BIND9, Unbound, Pi-hole, Traefik)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
       - name: Run shellcheck
-        uses: ludeeus/action-shellcheck@v2
-        with:
-          severity: warning
+        run: |
+          git ls-files '*.sh' | xargs -r shellcheck -S warning -x
 
       - name: Install shfmt
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,14 @@ logs/
 .env
 .env.*
 
+# Secrets/keys
+config/rndc.key
+traefik/acme/acme.json
+
+# Local volumes
+pihole/etc-pihole/
+pihole/etc-dnsmasq.d/
+
 # Docker
 docker-compose.override.yml
 

--- a/README.md
+++ b/README.md
@@ -1,37 +1,48 @@
-# turboDNS
+# hybrid-engine-dns
 
-Private WIP: a clean, reproducible, and privacy‑focused home lab DNS stack using Docker and BIND9/Unbound.
+A friendly, no‑nonsense DNS stack for your home lab. It blends BIND9 (authoritative), Unbound (recursive + DNSSEC), Pi-hole (filtering + UI), and Traefik (reverse proxy) so you get fast lookups, solid privacy, smart caching, clean ad/malware blocking, and sweet HTTPS on your internal subdomain.
 
-Goals
-- Professional structure and automation from day one
-- Strong defaults for privacy and security
-- Reproducible Docker-based deployment for home networks
+Why this exists
+- I like speed, privacy, and control — without duct tape
+- I want local names that make sense (hello, apps at home.example.com and example.lan)
+- I want Pi-hole’s blocklists plus proper recursive + authoritative DNS, all Dockerized
 
-Images used
-- ubuntu/bind9:9.18-22.04
-- bind9:9.18-22.04
+What you get
+- BIND9 for local zones and a private subdomain
+- Unbound for fast, privacy‑oriented recursive resolution (with DNS‑over‑TLS)
+- Pi-hole for ad/tracker blocking (bring your own lists)
+- Traefik reverse proxy with ACME DNS‑01 (wildcards) for your internal subdomain
+- Dockerized, reproducible setup tailored for home networks
 
 Status
-- This repository starts private while building. Once stabilized and documented, it will be made public.
+- WIP while I shape this up. Private for now; going public once the docs and defaults are tight.
 
-Quick start (placeholder)
-- Coming soon. This will include Docker Compose and configuration examples for BIND9 and Unbound.
+Placeholders and safety
+- This repo ships with sanitized example domains and IPs:
+  - Internal domain: example.lan
+  - Split‑DNS subdomain: home.example.com
+  - Example IPs: RFC 5737 test ranges (like 192.0.2.x)
+- Everywhere you see a TODO comment, swap in your real info. I’ll point it out inline.
+
+Quick start
+- Compose + configs are included with safe placeholders.
+- Start with the scripts in scripts/ or run docker compose up -d once you’ve filled the TODOs.
 
 Development
 - CI runs:
   - shellcheck (shell script static analysis)
   - shfmt (shell formatting checks)
-  - hadolint (Dockerfile linter)
-  - Trivy (repo/filesystem scan)
-- Dependencies and GitHub Actions are kept current via Dependabot.
+  - hadolint (Dockerfile linter, if Dockerfiles exist)
+  - Trivy (repo/filesystem scan, non‑blocking)
+- Dependabot keeps Actions and Docker bits fresh.
 
 Contributing
-- Please open an issue or start a Discussion to propose changes.
-- PRs should be small, focused, and include rationale.
+- Ideas and feedback welcome — start a Discussion or a focused PR.
+- Keep changes small and purposeful; explain the “why.”
 
 Security
 - See SECURITY.md for reporting guidance. Avoid filing public issues for vulnerabilities.
 
 License
-- Apache-2.0. See LICENSE for details.
+- Apache‑2.0. See LICENSE for details.
 

--- a/config/named.conf
+++ b/config/named.conf
@@ -1,0 +1,57 @@
+// Main BIND9 configuration file (sanitized)
+// Heads up: replace placeholder networks with your real VLAN CIDRs.
+
+// Include additional configuration files
+include "/etc/bind/named.conf.options";
+include "/etc/bind/named.conf.local";
+include "/etc/bind/named.conf.default-zones";
+
+// Access Control Lists (ACLs)
+acl "trusted" {
+    127.0.0.0/8;        // localhost
+    10.0.0.0/8;         // RFC 1918 - private
+    172.16.0.0/12;      // RFC 1918 - private
+    192.168.0.0/16;     // RFC 1918 - private
+    ::1;                // IPv6 localhost
+    fe80::/10;          // IPv6 link-local
+};
+
+acl "internal_networks" {
+    10.10.0.0/24;       // TODO: Default LAN (example)
+    10.20.0.0/24;       // TODO: Trusted LAN (example)
+    10.30.0.0/24;       // TODO: IoT LAN (example)
+    10.40.0.0/24;       // TODO: Monitors LAN (example)
+    192.168.50.0/24;    // TODO: Servers LAN (example)
+    10.0.0.0/8;         // Docker networks and other private ranges
+};
+
+// Logging configuration
+logging {
+    channel default_debug {
+        file "/var/log/bind/default.log" versions 5 size 50m;
+        severity dynamic;
+        print-time yes;
+        print-severity yes;
+        print-category yes;
+    };
+    
+    channel security_log {
+        file "/var/log/bind/security.log" versions 5 size 50m;
+        severity info;
+        print-time yes;
+        print-severity yes;
+        print-category yes;
+    };
+    
+    channel query_log {
+        file "/var/log/bind/query.log" versions 5 size 50m;
+        severity info;
+        print-time yes;
+    };
+    
+    category default { default_debug; };
+    category security { security_log; };
+    category queries { null; };
+    category lame-servers { null; };
+};
+

--- a/config/named.conf.default-zones
+++ b/config/named.conf.default-zones
@@ -1,0 +1,42 @@
+// Default zones configuration (unchanged from upstream)
+// These are the default zones required by BIND
+
+// Root zone
+zone "." {
+    type hint;
+    file "/usr/share/dns/root.hints";
+};
+
+// Localhost zones
+zone "localhost" {
+    type master;
+    file "/etc/bind/db.local";
+};
+
+zone "127.in-addr.arpa" {
+    type master;
+    file "/etc/bind/db.127";
+};
+
+zone "0.in-addr.arpa" {
+    type master;
+    file "/etc/bind/db.0";
+};
+
+zone "255.in-addr.arpa" {
+    type master;
+    file "/etc/bind/db.255";
+};
+
+// IPv6 localhost zones
+zone "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa" {
+    type master;
+    file "/etc/bind/db.empty";
+};
+
+// RFC 1912 zones
+zone "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa" {
+    type master;
+    file "/etc/bind/db.empty";
+};
+

--- a/config/named.conf.local
+++ b/config/named.conf.local
@@ -1,0 +1,79 @@
+// Local zones configuration (sanitized)
+// TODO: Replace example domains and reverse zones with your actual ones.
+
+// Forward zone for your internal-only domain
+zone "example.lan" {
+    type master;
+    file "/var/lib/bind/db.example.lan";
+    allow-update { none; };
+    allow-transfer { internal_networks; };
+    allow-query { internal_networks; };
+    // also-notify { 192.0.2.11; };  // TODO: Secondary IP (optional)
+};
+
+// Split-DNS subdomain for your public domain
+zone "home.example.com" {
+    type master;
+    file "/var/lib/bind/db.home.example.com";
+    allow-update { none; };
+    allow-transfer { internal_networks; };
+    allow-query { internal_networks; };
+    // also-notify { 192.0.2.11; };  // TODO: Secondary IP (optional)
+};
+
+// Reverse zones for example VLAN networks
+// Format: for network A.B.C.0/24, reverse zone is C.B.A.in-addr.arpa
+
+// Default LAN (example) - 10.10.0.0/24
+zone "0.10.10.in-addr.arpa" {
+    type master;
+    file "/var/lib/bind/db.10.10.0";
+    allow-update { none; };
+    allow-transfer { internal_networks; };
+    allow-query { internal_networks; };
+    // also-notify { 192.0.2.11; };  // Secondary (optional)
+};
+
+// Trusted LAN (example) - 10.20.0.0/24
+zone "0.20.10.in-addr.arpa" {
+    type master;
+    file "/var/lib/bind/db.10.20.0";
+    allow-update { none; };
+    allow-transfer { internal_networks; };
+    allow-query { internal_networks; };
+    // also-notify { 192.0.2.11; };
+};
+
+// IoT LAN (example) - 10.30.0.0/24
+zone "0.30.10.in-addr.arpa" {
+    type master;
+    file "/var/lib/bind/db.10.30.0";
+    allow-update { none; };
+    allow-transfer { internal_networks; };
+    allow-query { internal_networks; };
+    // also-notify { 192.0.2.11; };
+};
+
+// Monitors LAN (example) - 10.40.0.0/24
+zone "0.40.10.in-addr.arpa" {
+    type master;
+    file "/var/lib/bind/db.10.40.0";
+    allow-update { none; };
+    allow-transfer { internal_networks; };
+    allow-query { internal_networks; };
+    // also-notify { 192.0.2.11; };
+};
+
+// Servers LAN (example) - 192.168.50.0/24
+zone "50.168.192.in-addr.arpa" {
+    type master;
+    file "/var/lib/bind/db.192.168.50";
+    allow-update { none; };
+    allow-transfer { internal_networks; };
+    allow-query { internal_networks; };
+    // also-notify { 192.0.2.11; };
+};
+
+// Remote Name Daemon Control (RNDC) configuration
+include "/etc/bind/rndc.key";
+

--- a/config/named.conf.options
+++ b/config/named.conf.options
@@ -1,0 +1,51 @@
+// BIND9 options configuration - Authoritative-only mode
+// Recursive queries are handled by Unbound
+options {
+    directory "/var/cache/bind";
+    
+    // Authoritative-only: NO forwarders, NO recursion
+    recursion no;
+    allow-recursion { none; };
+    
+    // Security and access control
+    allow-query { trusted; internal_networks; };
+    allow-query-cache { none; };           // No cache for auth-only
+    allow-transfer { internal_networks; };  // Zone transfers only to internal networks
+    allow-update { none; };
+    
+    // Network settings - listen on all interfaces
+    listen-on port 53 { any; };
+    listen-on-v6 port 53 { any; };
+    
+    // Authoritative server settings
+    tcp-clients 100;
+    
+    // DNSSEC for authoritative zones only
+    dnssec-validation no;  // Unbound handles DNSSEC validation
+    dnssec-lookaside no;
+    
+    // Security features
+    auth-nxdomain no;
+    notify yes;             // Enable NOTIFY for zone updates (set to no if you don't use a secondary yet)
+    hostname none;
+    version none;
+    server-id none;
+    
+    // Response rate limiting
+    rate-limit {
+        responses-per-second 10;
+        window 5;
+    };
+    
+    // Authoritative server optimizations
+    minimal-responses yes;
+    additional-from-auth no;
+    additional-from-cache no;
+    
+    // Disable recursion-related features
+    fetch-glue no;
+    
+    // Query logging (optional)
+    // querylog yes;
+};
+

--- a/config/rndc.key.example
+++ b/config/rndc.key.example
@@ -1,0 +1,12 @@
+// RNDC Key example (do NOT commit real keys)
+// Generate a real key with: docker compose exec bind9 rndc-confgen -a
+key "rndc-key" {
+    algorithm hmac-sha256;
+    secret "YourBase64EncodedSecretKeyHere==";  // TODO: replace after generating
+};
+
+controls {
+    inet 127.0.0.1 port 953
+        allow { 127.0.0.1; } keys { "rndc-key"; };
+};
+

--- a/docker-compose.apps.example.yml
+++ b/docker-compose.apps.example.yml
@@ -1,0 +1,59 @@
+version: '3.8'
+
+# Example additional services using Docker labels with Traefik
+# Use with: docker compose -f docker-compose.yml -f docker-compose.apps.example.yml up -d
+
+services:
+  radarr:
+    image: lscr.io/linuxserver/radarr:latest
+    container_name: radarr
+    restart: unless-stopped
+    environment:
+      - PUID=1000           # TODO: set to your user ID
+      - PGID=1000           # TODO: set to your group ID
+      - TZ=UTC
+    volumes:
+      - ./apps/radarr/config:/config
+      - /srv/media:/media            # TODO: adjust to your media path
+    networks:
+      - dns_network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.radarr.rule=Host(`radarr.home.example.com`)"   # TODO: set your subdomain
+      - "traefik.http.routers.radarr.entrypoints=websecure"
+      - "traefik.http.routers.radarr.tls=true"
+      - "traefik.http.routers.radarr.tls.certresolver=le"
+      - "traefik.http.services.radarr.loadbalancer.server.port=7878"
+      - "traefik.http.routers.radarr.middlewares=secure-headers@file"
+      # Add basicauth if desired:
+      # - "traefik.http.routers.radarr.middlewares=secure-headers@file,basicauth@file"
+
+  sonarr:
+    image: lscr.io/linuxserver/sonarr:latest
+    container_name: sonarr
+    restart: unless-stopped
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=UTC
+    volumes:
+      - ./apps/sonarr/config:/config
+      - /srv/media:/media
+    networks:
+      - dns_network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.sonarr.rule=Host(`sonarr.home.example.com`)"   # TODO: set your subdomain
+      - "traefik.http.routers.sonarr.entrypoints=websecure"
+      - "traefik.http.routers.sonarr.tls=true"
+      - "traefik.http.routers.sonarr.tls.certresolver=le"
+      - "traefik.http.services.sonarr.loadbalancer.server.port=8989"
+      - "traefik.http.routers.sonarr.middlewares=secure-headers@file"
+      # - "traefik.http.routers.sonarr.middlewares=secure-headers@file,basicauth@file"
+
+networks:
+  # This network is defined in docker-compose.yml; when using multiple compose files,
+  # docker compose merges and reuses the same network.
+  dns_network:
+    external: false
+

--- a/docker-compose.secondary.yml
+++ b/docker-compose.secondary.yml
@@ -1,0 +1,48 @@
+version: '3.8'
+
+services:
+  bind9-secondary:
+    image: ubuntu/bind9:9.18-22.04
+    container_name: bind9-secondary
+    restart: unless-stopped
+    # RNDC on localhost-only, mapped to 954 to avoid conflict with primary
+    ports:
+      - "127.0.0.1:954:953/tcp"
+    volumes:
+      - ./config-secondary:/etc/bind
+      - ./zones-secondary:/var/lib/bind
+      - ./logs-secondary:/var/log/bind
+      - bind9_secondary_cache:/var/cache/bind
+    environment:
+      - TZ=UTC
+      - BIND9_USER=bind
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    ulimits:
+      nofile:
+        soft: 8192
+        hard: 8192
+    command: >
+      bash -c "
+      if [ ! -s /etc/bind/rndc.key ] || grep -q 'YourBase64EncodedSecretKeyHere' /etc/bind/rndc.key 2>/dev/null; then
+        rndc-confgen -a -A hmac-sha256 -b 256 -c /etc/bind/rndc.key -u bind;
+      fi &&
+      mkdir -p /var/lib/bind/slaves &&
+      chown -R bind:bind /var/lib/bind /var/log/bind /var/cache/bind &&
+      named -g -c /etc/bind/named.conf -u bind"
+    healthcheck:
+      test: ["CMD-SHELL", "rndc status || named-checkconf -z"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+volumes:
+  bind9_secondary_cache:
+    driver: local
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,178 @@
+version: '3.8'
+
+services:
+  # Traefik - reverse proxy with ACME DNS-01 (wildcard) and Docker+file providers
+  traefik:
+    image: traefik:v3.1
+    container_name: traefik
+    restart: unless-stopped
+    ports:
+      - "80:80/tcp"     # HTTP (redirects to HTTPS)
+      - "443:443/tcp"   # HTTPS
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./traefik/dynamic:/dynamic:ro
+      - ./traefik/acme:/acme
+      - ./traefik/auth:/auth:ro
+    environment:
+      - TZ=UTC
+      # ACME/Provider configuration is provided via env; define in .env (not committed)
+      # - ACME_EMAIL=<you@example.com>           # TODO: set your email for Let's Encrypt notifications
+      # - ACME_DNS_PROVIDER=cloudflare           # TODO: set your DNS provider (cloudflare, route53, etc.)
+      # - CF_DNS_API_TOKEN=<token>               # TODO: provider-specific token (see Traefik docs)
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --providers.file.directory=/dynamic
+      - --providers.file.watch=true
+      - --entrypoints.web.address=:80
+      - --entrypoints.web.http.redirections.entrypoint.to=websecure
+      - --entrypoints.web.http.redirections.entrypoint.scheme=https
+      - --entrypoints.websecure.address=:443
+      - --serversTransport.insecureSkipVerify=false
+      - --certificatesresolvers.le.acme.email=${ACME_EMAIL}
+      - --certificatesresolvers.le.acme.storage=/acme/acme.json
+      - --certificatesresolvers.le.acme.dnschallenge.provider=${ACME_DNS_PROVIDER}
+      - --certificatesresolvers.le.acme.dnschallenge.delayBeforeCheck=0
+      - --api.dashboard=false
+    networks:
+      dns_network:
+        ipv4_address: 172.20.0.8
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+    security_opt:
+      - no-new-privileges:true
+
+  # Unbound - Recursive DNS resolver with DNSSEC
+  unbound:
+    image: nlnetlabs/unbound:1.20.0
+    container_name: unbound-resolver
+    restart: unless-stopped
+    volumes:
+      - ./unbound:/opt/unbound/etc/unbound
+      - ./logs:/var/log/unbound
+      - unbound_cache:/opt/unbound/var/lib/unbound
+    environment:
+      - TZ=UTC
+    networks:
+      dns_network:
+        ipv4_address: 172.20.0.10
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    depends_on:
+      - bind9
+    command: >
+      sh -c "
+      mkdir -p /var/log/unbound &&
+      chown -R unbound:unbound /var/log/unbound /opt/unbound/var/lib/unbound &&
+      cd /opt/unbound/etc/unbound && [ -f unbound_control.key ] || unbound-control-setup &&
+      chown unbound:unbound unbound_control.key unbound_control.pem unbound_server.key unbound_server.pem &&
+      unbound -d -c /opt/unbound/etc/unbound/unbound.conf"
+    healthcheck:
+      test: ["CMD-SHELL", "unbound-control -c /opt/unbound/etc/unbound/unbound.conf status"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  # Pi-hole - DNS sinkhole and UI (front-end)
+  pihole:
+    image: pihole/pihole:latest
+    container_name: pihole
+    restart: unless-stopped
+    ports:
+      - "53:53/tcp"
+      - "53:53/udp"
+    environment:
+      - TZ=UTC
+      - DNSMASQ_LISTENING=local
+      - PIHOLE_DNS_1=172.20.0.10#53  # Unbound inside the network
+      - PIHOLE_DNS_2=172.20.0.10#53
+      - DNSSEC=false
+      # - WEBPASSWORD=${PIHOLE_WEBPASSWORD}   # TODO: set via env (not committed)
+    volumes:
+      - ./pihole/etc-pihole:/etc/pihole
+      - ./pihole/etc-dnsmasq.d:/etc/dnsmasq.d
+    networks:
+      dns_network:
+        ipv4_address: 172.20.0.9
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.pihole.rule=Host(`pihole.home.example.com`)"   # TODO: set your subdomain
+      - "traefik.http.routers.pihole.entrypoints=websecure"
+      - "traefik.http.routers.pihole.tls=true"
+      - "traefik.http.routers.pihole.tls.certresolver=le"
+      - "traefik.http.services.pihole.loadbalancer.server.port=80"
+      - "traefik.http.routers.pihole.middlewares=secure-headers@file,basicauth@file"
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+    security_opt:
+      - no-new-privileges:true
+    depends_on:
+      - unbound
+
+  # BIND9 - Authoritative DNS server for local zones
+  bind9:
+    image: ubuntu/bind9:9.18-22.04
+    container_name: bind9-authoritative
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:953:953/tcp"  # RNDC control port (localhost only)
+    volumes:
+      - ./config:/etc/bind
+      - ./zones:/var/lib/bind
+      - ./logs:/var/log/bind
+      - bind9_cache:/var/cache/bind
+    environment:
+      - TZ=UTC
+      - BIND9_USER=bind
+    networks:
+      dns_network:
+        ipv4_address: 172.20.0.11
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    ulimits:
+      nofile:
+        soft: 8192
+        hard: 8192
+    command: >
+      bash -c "
+      if [ ! -s /etc/bind/rndc.key ] || grep -q 'YourBase64EncodedSecretKeyHere' /etc/bind/rndc.key 2>/dev/null; then
+        rndc-confgen -a -A hmac-sha256 -b 256 -c /etc/bind/rndc.key -u bind;
+      fi &&
+      chown -R bind:bind /var/lib/bind /var/log/bind /var/cache/bind &&
+      named -g -c /etc/bind/named.conf -u bind"
+    healthcheck:
+      test: ["CMD-SHELL", "rndc status || named-checkconf -z"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+volumes:
+  bind9_cache:
+    driver: local
+  unbound_cache:
+    driver: local
+
+networks:
+  dns_network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.20.0.0/24
+

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -1,0 +1,73 @@
+# How to modify this repo (step by step)
+
+Friendly guide so Future You (and PR reviewers) stay happy.
+
+0) Ground rules (quick vibe check)
+- Never commit secrets. Use .env, config/rndc.key (ignored), and provider tokens via env.
+- Keep changes small and focused. One idea per PR.
+- Write docs and comments in a casual, confident tone. Helpful > formal.
+
+1) Branching
+- Base off main: git fetch origin && git switch -c <type>/<short-topic> origin/main
+- Name it like: feat/add-pihole-upstreams or fix/zone-typo or docs/readme-polish
+
+2) Make your changes
+- DNS zones: edit files under zones/ and bump the SOA serial (YYYYMMDDNN)
+- BIND config: config/named.conf* (authoritative only)
+- Unbound: unbound/unbound.conf (stub-zones, access-control, upstreams)
+- Traefik: traefik/dynamic/*.yml (hostnames, backends)
+- Compose: docker-compose*.yml (services, networks)
+- Scripts: scripts/*.sh (keep them POSIX-friendly and chill)
+
+3) Local checks (fast)
+- Shell: shellcheck scripts/*.sh (or let CI do it, but local is faster)
+- Format: shfmt -w scripts (CI runs -d to diff)
+- Dockerfiles (if any): hadolint <Dockerfile>
+- Optional: run docker compose config to validate compose syntax
+
+4) Run it (if applicable)
+- Start: ./scripts/start-dns.sh
+- Status: ./scripts/status-dns.sh
+- Logs: docker compose logs -f (or target a service)
+- Stop: ./scripts/stop-dns.sh
+
+5) Commit
+- Conventional-ish is great: "feat:", "fix:", "docs:", "chore:" etc.
+- Example: git add -A && git commit -m "feat: add split-DNS example zone"
+
+6) Push and open PR
+- git push -u origin <branch>
+- gh pr create --base main --head <branch> --title "feat: ..." --body "..."
+
+7) CI and reviews
+- Wait for the "ci" check to pass (lint/scan). Fix anything it flags.
+- Keep the convo friendly. If you change behavior, add a line to README or leave a crisp note.
+
+8) Merge
+- Squash merge is the default vibe (clean history). Auto-delete branches after merge is enabled.
+
+9) Post-merge
+- If you changed zones or configs, restart the stack:
+  - ./scripts/restart-dns.sh
+
+10) Versioning/Releases (optional)
+- If/when we start tagging releases, use SemVer: v0.1.0, v0.2.0, ...
+- Use GitHub Releases to write human-friendly release notes.
+
+Secrets playbook
+- .env (not committed): ACME_EMAIL, ACME_DNS_PROVIDER, provider tokens like CF_DNS_API_TOKEN
+- config/rndc.key: ignored; generate with: docker compose exec bind9 rndc-confgen -a
+- Never print secrets in logs or echo them in scripts
+
+Customization checklist
+- Domains: example.lan → your internal domain; home.example.com → your subdomain
+- Networks: replace 10.10/10.20/10.30/10.40 and 192.168.50 with your VLAN CIDRs
+- Traefik routes: point hostnames and backend URLs at your real services
+- Pi-hole: set WEBPASSWORD via env (and consider auth middleware in Traefik)
+
+Tone/style (docs + code comments)
+- Keep it casual, friendly, and confident (like you’ve done this before)
+- Be specific and helpful; prefer examples over theory
+- Use TODO notes where users must swap in their own values
+- Avoid shouting; emojis optional but welcomed where it helps
+

--- a/scripts/restart-dns.sh
+++ b/scripts/restart-dns.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Restart the hybrid DNS stack
+# Quick bounce to apply changes.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"$SCRIPT_DIR/stop-dns.sh"
+
+echo "⏳ Waiting 2s..."
+sleep 2
+
+"$SCRIPT_DIR/start-dns.sh"
+

--- a/scripts/start-dns.sh
+++ b/scripts/start-dns.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# Start the hybrid DNS stack (Pi-hole + Unbound + BIND9 + Traefik)
+# Casual but serious: this brings the whole thing up and does a few quick checks.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Compose CLI detection (docker compose v2 preferred)
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  DC="docker compose"
+elif command -v docker-compose >/dev/null 2>&1; then
+  DC="docker-compose"
+else
+  echo "❌ Error: Docker Compose not found. Install Docker Desktop or docker-compose."
+  exit 1
+fi
+
+echo "🚀 Firing up hybrid-engine-dns (Pi-hole + Unbound + BIND9 + Traefik)..."
+
+echo "📁 Project Directory: $PROJECT_DIR"
+
+# Check if Docker is running
+if ! docker info > /dev/null 2>&1; then
+  echo "❌ Error: Docker is not running. Please start Docker first."
+  exit 1
+fi
+
+# Create directories
+mkdir -p "$PROJECT_DIR/logs" "$PROJECT_DIR/unbound" "$PROJECT_DIR/traefik/acme" "$PROJECT_DIR/pihole/etc-pihole" "$PROJECT_DIR/pihole/etc-dnsmasq.d"
+
+# Set safe perms for Traefik ACME storage
+: > "$PROJECT_DIR/traefik/acme/acme.json" || true
+chmod 600 "$PROJECT_DIR/traefik/acme/acme.json" || true
+
+# Start containers
+cd "$PROJECT_DIR"
+$DC up -d
+
+# Basic health wait
+sleep 5
+
+# Quick status
+if $DC ps | grep -q "Up"; then
+  echo "✅ Stack is up! Here's what's running:"
+  $DC ps
+else
+  echo "❌ Failed to start. Recent logs:" && echo
+  $DC logs --since 5m || true
+  exit 1
+fi
+
+# Simple DNS smoke tests (uses example placeholders; swap to your domains when ready)
+if command -v dig >/dev/null 2>&1; then
+  echo
+  echo "🧪 Quick DNS tests (edit to your real domains when you customize):"
+  dig @127.0.0.1 example.com +short || echo "   External DNS test failed"
+  dig @127.0.0.1 example.lan SOA +short || echo "   Local domain test (example.lan) will fail until you customize zones"
+  dig @127.0.0.1 home.example.com SOA +short || echo "   Split-DNS test (home.example.com) will fail until you customize zones"
+fi
+
+echo
+echo "📋 Heads up:"
+echo "- Replace placeholder networks/domains in config/ and unbound/ to match your setup."
+echo "- Update Traefik hostnames under home.example.com to your real subdomain."
+echo "- Generate a real RNDC key: docker compose exec bind9 rndc-confgen -a"
+echo "- Then restart: $SCRIPT_DIR/restart-dns.sh"
+

--- a/scripts/status-dns.sh
+++ b/scripts/status-dns.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Hybrid DNS status and quick checks
+# Gives you a fast read on what’s running and whether lookups work.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  DC="docker compose"
+elif command -v docker-compose >/dev/null 2>&1; then
+  DC="docker-compose"
+else
+  echo "❌ Error: Docker Compose not found."
+  exit 1
+fi
+
+cd "$PROJECT_DIR"
+
+echo "📊 hybrid-engine-dns status"
+$DC ps || true
+
+echo
+echo "🧪 Basic DNS tests (edit to your real domains when customized):"
+if command -v dig >/dev/null 2>&1; then
+  echo -n "   External (example.com): "
+  if dig @127.0.0.1 example.com +short > /dev/null 2>&1; then echo "✅"; else echo "❌"; fi
+  echo -n "   Local domain (example.lan SOA): "
+  if dig @127.0.0.1 example.lan SOA +short > /dev/null 2>&1; then echo "✅"; else echo "❌"; fi
+  echo -n "   Split DNS (home.example.com SOA): "
+  if dig @127.0.0.1 home.example.com SOA +short > /dev/null 2>&1; then echo "✅"; else echo "❌"; fi
+else
+  echo "   (dig not installed)"
+fi
+
+echo
+echo "📝 Recent logs (last 5m):"
+$DC logs --since 5m | tail -n 100 || true
+

--- a/scripts/stop-dns.sh
+++ b/scripts/stop-dns.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Stop the hybrid DNS stack
+# Short and sweet.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  DC="docker compose"
+elif command -v docker-compose >/dev/null 2>&1; then
+  DC="docker-compose"
+else
+  echo "❌ Error: Docker Compose not found."
+  exit 1
+fi
+
+cd "$PROJECT_DIR"
+
+echo "🛑 Stopping hybrid-engine-dns..."
+$DC down || $DC stop
+
+echo "✅ Done."
+

--- a/traefik/acme/README.txt
+++ b/traefik/acme/README.txt
@@ -1,0 +1,4 @@
+# Traefik ACME files stored here
+# Create the file and restrict permissions before first start:
+#   mkdir -p traefik/acme && touch traefik/acme/acme.json && chmod 600 traefik/acme/acme.json
+

--- a/traefik/auth/README.txt
+++ b/traefik/auth/README.txt
@@ -1,0 +1,5 @@
+# Basic Auth credentials for middlewares.basicauth
+# Generate with:
+#   htpasswd -nbB <user> <password> | sed -e 's/\$/\$\$/g' > traefik/auth/.htpasswd
+# Then enable the basicauth middleware on your routers.
+

--- a/traefik/dynamic/routes.yml
+++ b/traefik/dynamic/routes.yml
@@ -1,0 +1,202 @@
+# Traefik file provider routes (sanitized)
+# Replace hostnames under home.example.com and example IPs/ports with your real services.
+
+http:
+  routers:
+    # NOTE: leave these as examples; copy and tweak for your setup
+    nas:
+      rule: Host(`nas.home.example.com`)           # TODO: set your subdomain
+      entryPoints: [websecure]
+      tls:
+        certResolver: le
+      middlewares: [secure-headers]
+      service: nas
+    pve:
+      rule: Host(`pve.home.example.com`)
+      entryPoints: [websecure]
+      tls:
+        certResolver: le
+      middlewares: [secure-headers]
+      service: pve
+    pbs:
+      rule: Host(`pbs.home.example.com`)
+      entryPoints: [websecure]
+      tls:
+        certResolver: le
+      middlewares: [secure-headers]
+      service: pbs
+    unifi:
+      rule: Host(`unifi.home.example.com`)
+      entryPoints: [websecure]
+      tls:
+        certResolver: le
+      middlewares: [secure-headers]
+      service: unifi
+    usw24:
+      rule: Host(`usw24.home.example.com`)
+      entryPoints: [websecure]
+      tls:
+        certResolver: le
+      middlewares: [secure-headers]
+      service: usw24
+    usw16:
+      rule: Host(`usw16.home.example.com`)
+      entryPoints: [websecure]
+      tls:
+        certResolver: le
+      middlewares: [secure-headers]
+      service: usw16
+    ap:
+      rule: Host(`ap.home.example.com`)
+      entryPoints: [websecure]
+      tls:
+        certResolver: le
+      middlewares: [secure-headers]
+      service: ap
+    idrac:
+      rule: Host(`idrac.home.example.com`)
+      entryPoints: [websecure]
+      tls:
+        certResolver: le
+      middlewares: [secure-headers, basicauth]
+      service: idrac
+    udm:
+      rule: Host(`udm.home.example.com`)
+      entryPoints: [websecure]
+      tls:
+        certResolver: le
+      middlewares: [secure-headers, basicauth]
+      service: udm
+    plex:
+      rule: Host(`plex.home.example.com`)
+      entryPoints: [websecure]
+      tls:
+        certResolver: le
+      middlewares: [secure-headers]
+      service: plex
+    dashboard:
+      rule: Host(`dashboard.home.example.com`)
+      entryPoints: [websecure]
+      tls:
+        certResolver: le
+      middlewares: [secure-headers]
+      service: dashboard
+    unvr:
+      rule: Host(`unvr.home.example.com`)
+      entryPoints: [websecure]
+      tls:
+        certResolver: le
+      middlewares: [secure-headers]
+      service: unvr
+    cyberchef:
+      rule: Host(`cyberchef.home.example.com`)
+      entryPoints: [websecure]
+      tls:
+        certResolver: le
+      middlewares: [secure-headers]
+      service: cyberchef
+    kuma:
+      rule: Host(`kuma.home.example.com`)
+      entryPoints: [websecure]
+      tls:
+        certResolver: le
+      middlewares: [secure-headers]
+      service: kuma
+    ha:
+      rule: Host(`ha.home.example.com`)
+      entryPoints: [websecure]
+      tls:
+        certResolver: le
+      middlewares: [secure-headers]
+      service: ha
+    homebridge:
+      rule: Host(`homebridge.home.example.com`)
+      entryPoints: [websecure]
+      tls:
+        certResolver: le
+      middlewares: [secure-headers]
+      service: homebridge
+    homey:
+      rule: Host(`homey.home.example.com`)
+      entryPoints: [websecure]
+      tls:
+        certResolver: le
+      middlewares: [secure-headers]
+      service: homey
+
+  services:
+    # Replace placeholder IPs/ports with real ones
+    nas:
+      loadBalancer:
+        servers:
+          - url: "http://192.0.2.10:80"     # TODO
+    pve:
+      loadBalancer:
+        servers:
+          - url: "https://192.0.2.11:8006"  # TODO: enable serversTransport if self-signed
+      serversTransport: selfsigned
+    pbs:
+      loadBalancer:
+        servers:
+          - url: "https://192.0.2.12:8007"
+      serversTransport: selfsigned
+    unifi:
+      loadBalancer:
+        servers:
+          - url: "https://192.0.2.13:8443"
+      serversTransport: selfsigned
+    usw24:
+      loadBalancer:
+        servers:
+          - url: "http://192.0.2.14:80"
+    usw16:
+      loadBalancer:
+        servers:
+          - url: "http://192.0.2.15:80"
+    ap:
+      loadBalancer:
+        servers:
+          - url: "http://192.0.2.16:80"
+    idrac:
+      loadBalancer:
+        servers:
+          - url: "https://192.0.2.17:443"
+      serversTransport: selfsigned
+    udm:
+      loadBalancer:
+        servers:
+          - url: "https://192.0.2.18:443"
+      serversTransport: selfsigned
+    plex:
+      loadBalancer:
+        servers:
+          - url: "http://192.0.2.19:32400"
+    dashboard:
+      loadBalancer:
+        servers:
+          - url: "http://192.0.2.20:80"
+    unvr:
+      loadBalancer:
+        servers:
+          - url: "http://192.0.2.21:7443"
+    cyberchef:
+      loadBalancer:
+        servers:
+          - url: "http://192.0.2.22:8000"
+    kuma:
+      loadBalancer:
+        servers:
+          - url: "http://192.0.2.23:3001"
+    ha:
+      loadBalancer:
+        servers:
+          - url: "http://192.0.2.31:8123"
+    homebridge:
+      loadBalancer:
+        servers:
+          - url: "http://192.0.2.32:8581"
+    homey:
+      loadBalancer:
+        servers:
+          - url: "http://192.0.2.33:80"
+

--- a/traefik/dynamic/tls.yml
+++ b/traefik/dynamic/tls.yml
@@ -1,0 +1,29 @@
+# Dynamic TLS and middleware configuration for Traefik
+
+tls:
+  options:
+    default:
+      minVersion: VersionTLS12
+      sniStrict: true
+      cipherSuites:
+        - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+
+http:
+  middlewares:
+    secure-headers:
+      headers:
+        frameDeny: true
+        contentTypeNosniff: true
+        browserXssFilter: true
+        referrerPolicy: "no-referrer-when-downgrade"
+        stsSeconds: 15552000
+        stsIncludeSubdomains: true
+        # stsPreload: true  # enable only if you plan to submit to the preload list
+    # Create /auth/.htpasswd (mounted read-only) to enable
+    basicauth:
+      basicAuth:
+        usersFile: "/auth/.htpasswd"
+

--- a/unbound/unbound.conf
+++ b/unbound/unbound.conf
@@ -1,0 +1,155 @@
+# Unbound configuration for hybrid-engine-dns (sanitized)
+# Replace placeholder networks and domains with yours, but keep the vibe clean.
+
+server:
+    # Basic server settings
+    verbosity: 1
+    interface: 0.0.0.0
+    port: 53
+    username: "unbound"
+    do-ip4: yes
+    do-ip6: yes
+    do-udp: yes
+    do-tcp: yes
+    
+    # Access control for your VLANs (examples)
+    access-control: 127.0.0.0/8 allow
+    access-control: 10.10.0.0/24 allow         # TODO: Default LAN
+    access-control: 10.20.0.0/24 allow         # TODO: Trusted LAN
+    access-control: 10.30.0.0/24 allow         # TODO: IoT LAN
+    access-control: 10.40.0.0/24 allow         # TODO: Monitors LAN
+    access-control: 192.168.50.0/24 allow      # TODO: Servers LAN
+    access-control: 172.20.0.0/24 allow        # Docker network
+    access-control: 0.0.0.0/0 refuse
+    
+    # Performance and caching
+    num-threads: 2
+    msg-cache-slabs: 4
+    rrset-cache-slabs: 4
+    infra-cache-slabs: 4
+    key-cache-slabs: 4
+    
+    # Cache settings
+    rrset-cache-size: 256m
+    msg-cache-size: 128m
+    so-rcvbuf: 1m
+    so-sndbuf: 1m
+    
+    # Network timeouts
+    outgoing-range: 4096
+    num-queries-per-thread: 2048
+    jostle-timeout: 200
+    delay-close: 10000
+    
+    # DNSSEC validation
+    auto-trust-anchor-file: "/opt/unbound/var/lib/unbound/root.key"
+    val-permissive-mode: no
+    val-clean-additional: yes
+    val-nsec3-keysize-iterations: "1024 150 2048 500 4096 2500"
+    key-cache-size: 100m
+    neg-cache-size: 10m
+    
+    # Privacy and security
+    hide-identity: yes
+    hide-version: yes
+    harden-glue: yes
+    harden-dnssec-stripped: yes
+    harden-below-nxdomain: yes
+    harden-referral-path: yes
+    harden-algo-downgrade: yes
+    use-caps-for-id: yes
+    qname-minimisation: yes
+    aggressive-nsec: yes
+    
+    # Prefetch settings for better performance
+    prefetch: yes
+    prefetch-key: yes
+    rrset-roundrobin: yes
+    
+    # Logging
+    logfile: "/var/log/unbound/unbound.log"
+    log-queries: no
+    log-replies: no
+    log-local-actions: yes
+    log-servfail: yes
+    
+    # Root hints (optional - Unbound has built-in root hints)
+    # root-hints: "/opt/unbound/etc/unbound/root.hints"
+    
+    # Local/private ranges so they don't leak upstream
+    private-address: 10.0.0.0/8
+    private-address: 172.16.0.0/12
+    private-address: 192.168.0.0/16
+    private-address: 169.254.0.0/16
+    private-address: fd00::/8
+    private-address: fe80::/10
+    private-address: ::ffff:0:0/96
+    
+    # Domain blocking (optional - uncomment to enable)
+    # include: "/opt/unbound/etc/unbound/blocklists.conf"
+
+# Forward local domain queries to BIND9 (authoritative)
+stub-zone:
+    name: "example.lan"                  # TODO: your internal-only domain
+    stub-addr: 172.20.0.11@53
+    stub-prime: no
+    stub-first: yes
+
+stub-zone:
+    name: "home.example.com"             # TODO: your internal subdomain of a public domain
+    stub-addr: 172.20.0.11@53
+    stub-prime: no
+    stub-first: yes
+
+# Forward reverse DNS for your example VLANs to BIND9
+stub-zone:
+    name: "0.10.10.in-addr.arpa"
+    stub-addr: 172.20.0.11@53
+    stub-prime: no
+    stub-first: yes
+
+stub-zone:
+    name: "0.20.10.in-addr.arpa"
+    stub-addr: 172.20.0.11@53
+    stub-prime: no
+    stub-first: yes
+
+stub-zone:
+    name: "0.30.10.in-addr.arpa"
+    stub-addr: 172.20.0.11@53
+    stub-prime: no
+    stub-first: yes
+
+stub-zone:
+    name: "0.40.10.in-addr.arpa"
+    stub-addr: 172.20.0.11@53
+    stub-prime: no
+    stub-first: yes
+
+stub-zone:
+    name: "50.168.192.in-addr.arpa"
+    stub-addr: 172.20.0.11@53
+    stub-prime: no
+    stub-first: yes
+
+# DNS-over-TLS upstream resolvers (enabled by default)
+forward-zone:
+    name: "."
+    forward-tls-upstream: yes
+    forward-addr: 1.1.1.1@853#cloudflare-dns.com
+    forward-addr: 1.0.0.1@853#cloudflare-dns.com
+    forward-addr: 9.9.9.9@853#dns.quad9.net
+    forward-addr: 149.112.112.112@853#dns.quad9.net
+    forward-addr: 8.8.8.8@853#dns.google
+    forward-addr: 8.8.4.4@853#dns.google
+
+# Remote control (for unbound-control)
+remote-control:
+    control-enable: yes
+    control-interface: 127.0.0.1
+    control-port: 8953
+    server-key-file: "/opt/unbound/etc/unbound/unbound_server.key"
+    server-cert-file: "/opt/unbound/etc/unbound/unbound_server.pem"
+    control-key-file: "/opt/unbound/etc/unbound/unbound_control.key"
+    control-cert-file: "/opt/unbound/etc/unbound/unbound_control.pem"
+

--- a/zones/db.10.10.0
+++ b/zones/db.10.10.0
@@ -1,0 +1,21 @@
+; Reverse zone file (example) - 10.10.0.0/24
+
+$TTL    604800
+@       IN      SOA     ns1.example.lan. admin.example.lan. (
+                         2025090801 ; Serial (YYYYMMDDNN)
+                         604800     ; Refresh
+                         86400      ; Retry
+                         2419200    ; Expire
+                         604800 )   ; Negative Cache TTL
+
+; Name servers
+@       IN      NS      ns1.example.lan.
+@       IN      NS      ns2.example.lan.
+
+; PTR records (examples)
+1       IN      PTR     router.example.lan.
+2       IN      PTR     switch-main.example.lan.
+3       IN      PTR     firewall.example.lan.
+100     IN      PTR     workstation1.example.lan.
+101     IN      PTR     workstation2.example.lan.
+

--- a/zones/db.10.20.0
+++ b/zones/db.10.20.0
@@ -1,0 +1,19 @@
+; Reverse zone file (example) - 10.20.0.0/24
+
+$TTL    604800
+@       IN      SOA     ns1.example.lan. admin.example.lan. (
+                         2025090801 ; Serial (YYYYMMDDNN)
+                         604800     ; Refresh
+                         86400      ; Retry
+                         2419200    ; Expire
+                         604800 )   ; Negative Cache TTL
+
+; Name servers
+@       IN      NS      ns1.example.lan.
+@       IN      NS      ns2.example.lan.
+
+; PTR records (examples)
+1       IN      PTR     gateway-trusted.example.lan.
+100     IN      PTR     admin-pc.example.lan.
+200     IN      PTR     backup-server.example.lan.
+

--- a/zones/db.10.30.0
+++ b/zones/db.10.30.0
@@ -1,0 +1,21 @@
+; Reverse zone file (example) - 10.30.0.0/24
+
+$TTL    604800
+@       IN      SOA     ns1.example.lan. admin.example.lan. (
+                         2025090801 ; Serial (YYYYMMDDNN)
+                         604800     ; Refresh
+                         86400      ; Retry
+                         2419200    ; Expire
+                         604800 )   ; Negative Cache TTL
+
+; Name servers
+@       IN      NS      ns1.example.lan.
+@       IN      NS      ns2.example.lan.
+
+; PTR records (examples)
+1       IN      PTR     gateway-iot.example.lan.
+10      IN      PTR     hub-zigbee.example.lan.
+11      IN      PTR     hub-zwave.example.lan.
+20      IN      PTR     smart-thermostat.example.lan.
+21      IN      PTR     smart-doorbell.example.lan.
+

--- a/zones/db.10.40.0
+++ b/zones/db.10.40.0
@@ -1,0 +1,19 @@
+; Reverse zone file (example) - 10.40.0.0/24
+
+$TTL    604800
+@       IN      SOA     ns1.example.lan. admin.example.lan. (
+                         2025090801 ; Serial (YYYYMMDDNN)
+                         604800     ; Refresh
+                         86400      ; Retry
+                         2419200    ; Expire
+                         604800 )   ; Negative Cache TTL
+
+; Name servers
+@       IN      NS      ns1.example.lan.
+@       IN      NS      ns2.example.lan.
+
+; PTR records (examples)
+1       IN      PTR     gateway-monitors.example.lan.
+10      IN      PTR     prometheus.example.lan.
+11      IN      PTR     grafana.example.lan.
+

--- a/zones/db.192.168.50
+++ b/zones/db.192.168.50
@@ -1,0 +1,19 @@
+; Reverse zone file (example) - 192.168.50.0/24
+
+$TTL    604800
+@       IN      SOA     ns1.example.lan. admin.example.lan. (
+                         2025090801 ; Serial (YYYYMMDDNN)
+                         604800     ; Refresh
+                         86400      ; Retry
+                         2419200    ; Expire
+                         604800 )   ; Negative Cache TTL
+
+; Name servers
+@       IN      NS      ns1.example.lan.
+@       IN      NS      ns2.example.lan.
+
+; PTR records (examples)
+1       IN      PTR     gateway-servers.example.lan.
+20      IN      PTR     docker-host.example.lan.
+40      IN      PTR     web.example.lan.
+

--- a/zones/db.example.lan
+++ b/zones/db.example.lan
@@ -1,0 +1,60 @@
+; Zone file for example.lan (sanitized)
+; Heads up: replace hostnames and IPs with your actual values.
+
+$TTL    604800
+@       IN      SOA     ns1.example.lan. admin.example.lan. (
+                         2025090801 ; Serial (YYYYMMDDNN format)
+                         604800     ; Refresh (1 week)
+                         86400      ; Retry (1 day)
+                         2419200    ; Expire (4 weeks)
+                         604800 )   ; Negative Cache TTL (1 week)
+
+; Name servers
+@       IN      NS      ns1.example.lan.
+@       IN      NS      ns2.example.lan.
+
+; A records (IPv4) organized by VLAN (examples)
+
+; DNS Infrastructure (typically on Servers VLAN)
+ns1             IN      A       192.0.2.10    ; TODO: Primary DNS server IP
+ns2             IN      A       192.0.2.11    ; TODO: Secondary DNS server IP
+
+; Default LAN (example) - 10.10.0.0/24
+router          IN      A       10.10.0.1     ; TODO: main router/gateway
+switch-main     IN      A       10.10.0.2
+firewall        IN      A       10.10.0.3
+workstation1    IN      A       10.10.0.100
+workstation2    IN      A       10.10.0.101
+
+; Trusted LAN (example) - 10.20.0.0/24
+gateway-trusted IN      A       10.20.0.1
+admin-pc        IN      A       10.20.0.100
+backup-server   IN      A       10.20.0.200
+
+; IoT LAN (example) - 10.30.0.0/24
+gateway-iot     IN      A       10.30.0.1
+hub-zigbee      IN      A       10.30.0.10
+hub-zwave       IN      A       10.30.0.11
+smart-thermostat IN     A       10.30.0.20
+smart-doorbell  IN      A       10.30.0.21
+
+; Monitors LAN (example) - 10.40.0.0/24
+gateway-monitors IN     A       10.40.0.1
+prometheus      IN      A       10.40.0.10
+grafana         IN      A       10.40.0.11
+
+; Servers LAN (example) - 192.168.50.0/24
+gateway-servers IN      A       192.168.50.1
+docker-host     IN      A       192.168.50.20
+web             IN      A       192.168.50.40
+
+; AAAA records (IPv6) - Optional, uncomment and modify as needed
+; ns1            IN      AAAA    2001:db8::10
+; web            IN      AAAA    2001:db8::40
+
+; CNAME records (Aliases)
+www             IN      CNAME   web.example.lan.
+api             IN      CNAME   web.example.lan.
+
+auth            IN      TXT     "v=spf1 ip4:192.0.2.0/24 ~all"  ; TODO: replace SPF range
+

--- a/zones/db.home.example.com
+++ b/zones/db.home.example.com
@@ -1,0 +1,37 @@
+; Zone file for home.example.com (internal split DNS)
+; Replace hostnames and IP addresses to match your environment.
+
+$TTL    604800
+@       IN      SOA     ns1.example.lan. admin.example.lan. (
+                         2025090801 ; Serial (YYYYMMDDNN format)
+                         604800     ; Refresh (1 week)
+                         86400      ; Retry (1 day)
+                         2419200    ; Expire (4 weeks)
+                         604800 )   ; Negative Cache TTL (1 week)
+
+; Name servers for this internal subdomain
+@       IN      NS      ns1.example.lan.
+
+; Example host records (placeholders)
+nas             IN      A       192.0.2.10     ; TODO
+pve             IN      A       192.0.2.11     ; TODO
+pbs             IN      A       192.0.2.12     ; TODO
+unifi           IN      A       192.0.2.13     ; TODO
+usw24           IN      A       192.0.2.14     ; TODO
+usw16           IN      A       192.0.2.15     ; TODO
+ap              IN      A       192.0.2.16     ; TODO
+idrac           IN      A       192.0.2.17     ; TODO
+udm             IN      A       192.0.2.18     ; TODO
+plex            IN      A       192.0.2.19     ; TODO
+dashboard       IN      A       192.0.2.20     ; TODO
+unvr            IN      A       192.0.2.21     ; TODO
+cyberchef       IN      A       192.0.2.22     ; TODO
+kuma            IN      A       192.0.2.23     ; TODO
+ha              IN      A       192.0.2.31     ; TODO
+homebridge      IN      A       192.0.2.32     ; TODO
+homey           IN      A       192.0.2.33     ; TODO
+
+; Aliases (CNAMEs)
+proxmox         IN      CNAME   pve.home.example.com.
+kibana          IN      CNAME   dashboard.home.example.com.
+


### PR DESCRIPTION
This PR imports your DNS stack with all sensitive bits sanitized and comments updated to be friendly and clear.\n\nWhat’s in:\n- docker-compose (primary + secondary) and example apps file\n- BIND9 + Unbound configs with example networks/domains\n- Traefik dynamic config (routes + TLS)\n- Example forward/reverse zones for example.lan and home.example.com\n- Scripts to start/stop/restart/status\n- README rewritten in a casual, confident tone\n- docs/MAINTENANCE.md with step-by-step modification guide\n- .gitignore additions for secrets and local volumes\n\nNotes:\n- Replace placeholders (example.lan, home.example.com, 10.10/20/30/40, 192.168.50, and 192.0.2.x hosts) with your real values.\n- Generate a real RNDC key after merge: docker compose exec bind9 rndc-confgen -a\n- Traefik uses DNS-01; configure .env with ACME vars (email, provider, token).\n\nMerging this will set the baseline, then we’ll layer in your actual compose/customizations as you share them.