### PR TITLE
fix(ci): use stable ubuntu/bind9 tag to fix container scans

### DIFF
--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - "ubuntu/bind9:9.18-24.04_edge"
+          - "ubuntu/bind9:9.18-22.04_lts"
           - "pihole/pihole:2024.07.0"
           - "mvance/unbound:1.21.1"
           - "traefik:v3.1"


### PR DESCRIPTION
🔧 **Fixes the red X in container security scans**

**Problem:** The `ubuntu/bind9:9.18-24.04_edge` tag was unstable and causing CI failures

**Solution:** Switch to the stable LTS tag: `ubuntu/bind9:9.18-22.04_lts`

**Result:** Container security scans should now pass ✅

This resolves the recurring red crosses in the CI workflow.